### PR TITLE
Ryan/feature/lift state

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,7 +1,7 @@
 import '../App.css'
 import { Landing } from '../components/Landing'
 import { DemoUsers } from '../features/users/DemoUsers'
-import { Main } from '../features/restaurants/Dashboard'
+import { Dashboard } from '../features/restaurants/Dashboard'
 import { Error } from '../components/Error'
 import { Routes, Route, NavLink } from 'react-router-dom'
 import { APP_ROUTES } from '../utilities/constants'
@@ -12,7 +12,7 @@ function App() {
         <Routes>
           <Route path={APP_ROUTES.LANDING} element={(<Landing />)} />
           <Route path={APP_ROUTES.DEMO} element={(<DemoUsers />)} />
-          <Route path={APP_ROUTES.DASH} element={(<Main />)} />
+          <Route path={APP_ROUTES.DASH} element={(<Dashboard />)} />
           <Route path='/*' element={(<Error message='404 Page Not Found'/>)} />
         </Routes>
     </div>

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -2,12 +2,14 @@ import { configureStore } from '@reduxjs/toolkit'
 import usersReducer from '../features/users/usersSlice'
 import restaurantsReducer from '../features/restaurants/restaurantsSlice'
 import filtersReducer from '../features/filters/filtersSlice'
+import liftsReducer from '../features/lifts/liftsSlice'
 
 export const store = configureStore({
   reducer: {
     users: usersReducer,
     restaurants: restaurantsReducer,
     filters: filtersReducer,
+    lifts: liftsReducer,
   },
 })
 

--- a/src/features/lifts/liftsSlice.ts
+++ b/src/features/lifts/liftsSlice.ts
@@ -1,0 +1,44 @@
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit'
+import { CleanedLiftsState } from '../../utilities/interfaces'
+import { fetchLifts } from '../../utilities/APICalls'
+import { cleanListData } from '../../utilities/utilities'
+
+export interface LiftsState {
+  lifts: CleanedLiftsState[]
+  status: string
+  error: string | null
+}
+
+const initialState: LiftsState = {
+  lifts: [] as CleanedLiftsState[],
+  status: 'idle',
+  error: null,
+}
+
+export const getLifts = createAsyncThunk('restaurants/fetchLifts', async () => {
+  const response = await fetchLifts()
+  const lifts = cleanListData(response.data)
+  return lifts
+})
+
+export const liftsSlice = createSlice({
+  name: 'lifts',
+  initialState,
+  reducers: {},
+  extraReducers(builder) {
+    builder
+      .addCase(getLifts.pending, (state, action) => {
+        state.status = 'loading'
+      })
+      .addCase(getLifts.fulfilled, (state, action) => {
+        state.status = 'succeeded'
+        state.lifts = action.payload
+      })
+      .addCase(getLifts.rejected, (state, action) => {
+        state.status = 'failed'
+        state.error = action.error.message as any
+      })
+  },
+})
+
+export default liftsSlice.reducer

--- a/src/features/lifts/liftsSlice.ts
+++ b/src/features/lifts/liftsSlice.ts
@@ -5,14 +5,14 @@ import { cleanListData } from '../../utilities/utilities'
 
 export interface LiftsState {
   lifts: CleanedLiftsState[]
-  status: string
-  error: string | null
+  liftsStatus: string
+  liftsError: string | null
 }
 
 const initialState: LiftsState = {
   lifts: [] as CleanedLiftsState[],
-  status: 'idle',
-  error: null,
+  liftsStatus: 'idle',
+  liftsError: null,
 }
 
 export const getLifts = createAsyncThunk('restaurants/fetchLifts', async () => {
@@ -28,15 +28,15 @@ export const liftsSlice = createSlice({
   extraReducers(builder) {
     builder
       .addCase(getLifts.pending, (state, action) => {
-        state.status = 'loading'
+        state.liftsStatus = 'loading'
       })
       .addCase(getLifts.fulfilled, (state, action) => {
-        state.status = 'succeeded'
+        state.liftsStatus = 'succeeded'
         state.lifts = action.payload
       })
       .addCase(getLifts.rejected, (state, action) => {
-        state.status = 'failed'
-        state.error = action.error.message as any
+        state.liftsStatus = 'failed'
+        state.liftsError = action.error.message as any
       })
   },
 })

--- a/src/features/lifts/liftsSlice.ts
+++ b/src/features/lifts/liftsSlice.ts
@@ -1,7 +1,7 @@
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit'
 import { CleanedLiftsState } from '../../utilities/interfaces'
 import { fetchLifts } from '../../utilities/APICalls'
-import { cleanListData } from '../../utilities/utilities'
+import { cleanLiftsData } from '../../utilities/utilities'
 
 export interface LiftsState {
   lifts: CleanedLiftsState[]
@@ -17,7 +17,7 @@ const initialState: LiftsState = {
 
 export const getLifts = createAsyncThunk('restaurants/fetchLifts', async () => {
   const response = await fetchLifts()
-  const lifts = cleanListData(response.data)
+  const lifts = cleanLiftsData(response.data)
   return lifts
 })
 

--- a/src/features/restaurants/Dashboard.tsx
+++ b/src/features/restaurants/Dashboard.tsx
@@ -11,12 +11,14 @@ import { Error } from '../../components/Error'
 import { useNavigate } from 'react-router-dom'
 import { APP_ROUTES } from '../../utilities/constants'
 import { Button } from 'react-bootstrap'
+import { getLifts } from '../lifts/liftsSlice' 
 
 export const Main = () => {
   const dispatch = useDispatch<AppDispatch>()
   const navigate = useNavigate()
-  const { status, error } = useSelector((state: RootState) => state.restaurants)
+  const { status } = useSelector((state: RootState) => state.restaurants)
   const { activeUser } = useSelector((state: RootState) => state.users)
+  const { liftsStatus } = useSelector((state: RootState) => state.lifts)
   const [show, setShow] = useState(false)
   const handleClose = () => setShow(false)
   const handleShow = () => setShow(true)
@@ -32,6 +34,12 @@ export const Main = () => {
       dispatch(getRestaurants())
     }
   }, [status, dispatch])
+
+  useEffect(() => {
+    if (liftsStatus === 'idle') {
+      dispatch(getLifts())
+    }
+  }, [liftsStatus, dispatch])
 
   let content
 

--- a/src/features/restaurants/Dashboard.tsx
+++ b/src/features/restaurants/Dashboard.tsx
@@ -13,7 +13,7 @@ import { APP_ROUTES } from '../../utilities/constants'
 import { Button } from 'react-bootstrap'
 import { getLifts } from '../lifts/liftsSlice' 
 
-export const Main = () => {
+export const Dashboard = () => {
   const dispatch = useDispatch<AppDispatch>()
   const navigate = useNavigate()
   const { status } = useSelector((state: RootState) => state.restaurants)

--- a/src/utilities/APICalls.ts
+++ b/src/utilities/APICalls.ts
@@ -29,3 +29,18 @@ export const fetchUsers = async () => {
     return error
   }
 }
+
+export const fetchLifts = async () => {
+  try {
+    const response = await fetch(API_ROUTES.GET_LIFTS, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
+
+    return await response.json()
+  } catch (error) {
+    return error
+  }
+}

--- a/src/utilities/constants.ts
+++ b/src/utilities/constants.ts
@@ -2,7 +2,8 @@ const API_URL = 'http://127.0.0.1:8000/'
 
 export const API_ROUTES = {
   GET_RESTAURANTS: `${API_URL}api/v1/restaurant/`,
-  GET_USERS: `${API_URL}api/v1/user/`
+  GET_USERS: `${API_URL}api/v1/user/`,
+  GET_LIFTS: `${API_URL}api/v1/lift/`
 }
 
 export const APP_ROUTES = {

--- a/src/utilities/interfaces.ts
+++ b/src/utilities/interfaces.ts
@@ -127,3 +127,21 @@ export interface CleanedUserState {
     long: string
   }
 }
+
+export interface Lifts {
+  id: string
+  attributes: {
+    name: string
+    lat: string
+    lon: string
+  }
+}
+
+export interface CleanedLiftsState {
+  id: string
+  name: string
+  location: {
+    lat: string
+    long: string
+  }
+}

--- a/src/utilities/utilities.ts
+++ b/src/utilities/utilities.ts
@@ -4,6 +4,8 @@ import {
   Engagement,
   Restaurants,
   Users,
+  Lifts,
+  CleanedLiftsState
 } from './interfaces'
 
 export const cleanList = (
@@ -88,5 +90,18 @@ export const cleanUsersData = (users: Users[]): CleanedUserState[] => {
         long: user.attributes.lon,
       },
     } as CleanedUserState
+  })
+}
+
+export const cleanListData = (lifts: Lifts[]): CleanedLiftsState[] => {
+  return lifts.map((lift: Lifts) => {
+    return {
+      id: lift.id,
+      name: lift.attributes.name,
+      location: {
+        lat: lift.attributes.lat,
+        long: lift.attributes.lon,
+      }
+    }
   })
 }

--- a/src/utilities/utilities.ts
+++ b/src/utilities/utilities.ts
@@ -93,7 +93,7 @@ export const cleanUsersData = (users: Users[]): CleanedUserState[] => {
   })
 }
 
-export const cleanListData = (lifts: Lifts[]): CleanedLiftsState[] => {
+export const cleanLiftsData = (lifts: Lifts[]): CleanedLiftsState[] => {
   return lifts.map((lift: Lifts) => {
     return {
       id: lift.id,


### PR DESCRIPTION
Type of change

- [x] New feature
- [ ] Bug Fix
- [ ] Refactor

Implements/Fixes:
- Adds `fetchLifts` to APICalls
- Adds `Lifts` and `CleanedLiftsState` to the interfaces
- Adds `cleanLiftsData` to utilities
- Adds a `liftsSlice` with a thunk and extraReducers in it
- dispatches `getLifts` in `Dashboard.tsx`
- Currently none of the Dashboard rendering logic depends on the status of the getLifts call. I figured we would still want to show the restaurants if the lift call broke in some way. The lifts are more-so there for landmarks/extra information

description closes issue #
#60 

Checklist:

- [x] I have reviewed my code
- [x] My code has no unused/commented out code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have fully tested my code
- [ ] All Tests are Passing
- [x] The code will run locally

Please gif your feelings about this PR:
<img src="https://media3.giphy.com/media/24bc6h4Mo05pG4XqaU/giphy.gif"/>